### PR TITLE
Patch ClientHelpers for xsrf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "derelict",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Easy Stateless Authentication for Express",
   "main": "dist/index.js",
   "scripts": {

--- a/src/clientHelpers.js
+++ b/src/clientHelpers.js
@@ -18,7 +18,7 @@ export function getXSRF() {
   var xsrf = getCookie('X-ACCESS-XSRF');
 
   if (xsrf) {
-    headers.xsrf = xsrf;
+    headers['x-access-xsrf'] = xsrf;
   }
 
   return headers;


### PR DESCRIPTION
## Changes
- Store XSRF string in headers using 'x-access-xsrf' - derelict is trying to get the header from there.