### PR TITLE
SSL Domain Option

### DIFF
--- a/docs/derelict_setup.md
+++ b/docs/derelict_setup.md
@@ -106,11 +106,13 @@ const authConfig = {
     updateUser,
     authRules,
     secret: 'aSecretForEncodingJWT',
-    useXSRF: true // You can omit this, the default setting is true
+    sslDomain: 'website.com'
 }
 
 derelict.setup(authConfig);
 ```
+
+Passing the sslDomain will cause derelict to Secure and Domain directives on the cookies.
 
 ## Next Step
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "derelict",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Easy Stateless Authentication for Express",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ const derelict = (function() {
       updateUser,
       authRules,
       refresh,
-      onFail
+      onFail,
+      sslDomain
     }) {
       if (refresh) {
         useRefresh = true;
@@ -40,7 +41,7 @@ const derelict = (function() {
       authenticator = Authenticator(jwt, createUser, fetchUser, updateUser);
       onAuthFail = onFail || onAuthFail;
       augmentRequest(jwt, authRules);
-      augmentResponse(jwt, accessTokenExpiry, refreshTokenExpiry);
+      augmentResponse(jwt, accessTokenExpiry, refreshTokenExpiry, sslDomain);
     },
 
     signUp(req, res, next) {

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -1,15 +1,14 @@
 import request from 'supertest';
 import { assert } from 'chai';
 import setupServer from './testServer';
-import { createUser, fetchUser, updateUser, authRules, next } from './helpers';
+import { createUser, fetchUser, updateUser, authRules } from './helpers';
 
 const defaultConfig = {
   createUser,
   fetchUser,
   updateUser,
   authRules,
-  secret: 'testymctestface',
-  next
+  secret: 'testymctestface'
 };
 
 let server;


### PR DESCRIPTION
## Changes
- Add sslDomain option - passing in a domain string will cause derelict to set Secure and Domain directives on the jwt and xsrf cookies
- Update tests to handle above
- Remove unused import in test
- Bump version number